### PR TITLE
feat(observability): Add Websockets integration with back-end CDK

### DIFF
--- a/src/sections/dashboard/view/dashboard-view.tsx
+++ b/src/sections/dashboard/view/dashboard-view.tsx
@@ -3,14 +3,85 @@ import Typography from '@mui/material/Typography';
 
 import { _timeline } from 'src/_mock';
 import { DashboardContent } from 'src/layouts/dashboard';
+import { Box, CircularProgress } from '@mui/material';
 
 import { EventLogs } from '../event-logs';
 import { DataMetrics } from '../data-metrics';
 import { OverviewCard } from '../overview-card';
+import { useWebSocket } from './useWebSocket';
+
+
 
 // ----------------------------------------------------------------------
 
 export function DashboardView() {
+  const { data, loading, isConnected } = useWebSocket();
+
+const getLogType = (message: string): string => {
+  if (message.includes('ingest process finished in') || message.includes('writing a total')) {
+    return 'type1';  // Success
+  }
+  if (message.includes('Deleting')) {
+    return 'type4';  // Deletion
+  }
+  if (message.includes('PartitionStep') || message.includes('ChunkStep') || message.includes('EmbedStep')) {
+    return 'type2';  // Partitioning
+  }
+  if (message.includes('error') || message.includes('failed')) {
+    return 'type6' // Error
+  }
+  return 'type8';  // Default
+};
+
+const cleanLogMessage = (message: string): string => {
+  const regex = /^(.*?)(Process)\s+/;
+  return message.replace(regex, '');
+};
+
+const mappedLogs = data?.logs?.map((log, index) => ({
+  id: `log-${index}`,
+  type: getLogType(log.message),
+  title: cleanLogMessage(log.message),
+  time: log.timestamp,
+})) ?? [];
+
+  const totalVectors = data?.totalVectors || 0;
+  const totalDocuments = data?.totalDocuments || 0;
+  const vectorsWritten = data?.vectorsWritten || 0;
+  const documentsIngested = data?.documentsIngested || 0;
+
+  const sourceDestinationEmbedding = data?.sourceDestinationEmbedding || '||';
+  const [source, destination, embedding] = sourceDestinationEmbedding.split('|');
+  const sourceConnector = source || 'Unknown Source';
+  const destinationConnector = destination || 'Unknown Destination';
+  const embeddingProvider = embedding || 'Unknown Embedding';
+
+  const jobStatusCounts = data?.jobStatusCounts || {
+    SUBMITTED: 0,
+    STARTING: 0,
+    PENDING: 0,
+    RUNNING: 0,
+    SUCCEEDED: 0,
+    FAILED: 0,
+  };
+
+  if (loading) {
+    return (
+      <Box
+        display="flex"
+        flexDirection="column"
+        alignItems="center"
+        justifyContent="center"
+        height="100vh"
+      >
+        <CircularProgress size={50} color="primary" />
+        <Typography variant="h6" sx={{ marginTop: 2 }}>
+          Loading data, please wait...
+        </Typography>
+      </Box>
+    );
+  }
+
   return (
     <DashboardContent maxWidth="xl">
       <Typography variant="h4" sx={{ mb: { xs: 3, md: 5 } }}>
@@ -30,7 +101,7 @@ export function DashboardView() {
         <Grid xs={12} sm={6} md={3}>
           <OverviewCard
             title="Source Connector"
-            text="S3"
+            text={sourceConnector}
             color="warning"
             icon={<img alt="icon" src="/assets/icons/dashboard/ic-source.svg" />}
           />
@@ -39,8 +110,8 @@ export function DashboardView() {
         <Grid xs={12} sm={6} md={3}>
           <OverviewCard
             title="Destination Connector"
-            text="Pinecone"
-            color="warning"
+            text={destinationConnector}
+            color="info"
             icon={<img alt="icon" src="/assets/icons/dashboard/ic-database.svg" />}
           />
         </Grid>
@@ -48,28 +119,41 @@ export function DashboardView() {
         <Grid xs={12} sm={6} md={3}>
           <OverviewCard
             title="Embedding Provider"
-            text="OpenAI"
-            color="error"
+            text={embeddingProvider}
+            color="secondary"
             icon={<img alt="icon" src="/assets/icons/dashboard/ic-embedding.svg" />}
           />
         </Grid>
 
-        <Grid xs={12} md={6} lg={4}>
+        <Grid xs={12} sm={6} md={6} lg={6}>
           <DataMetrics
             title="Data Ingestion"
             list={[
-              { label: 'Total Documents', total: 268 },
-              { label: 'Ingested Documents', total: 230 },
-              { label: 'Chunks Written', total: 3419 },
-              { label: 'Vectors Written', total: 3012 },
+              { label: 'Documents Ingested', total: documentsIngested },
+              { label: 'Vectors Written', total: vectorsWritten },
+              { label: 'Documents in Database', total: totalDocuments },
+              { label: 'Vectors in Database', total: totalVectors },
             ]}
           />
         </Grid>
 
-        <Grid xs={12} md={6} lg={8}>
-          <EventLogs title="Event Logs" list={_timeline} />
+        <Grid xs={12} sm={6} md={6} lg={6}>
+          <DataMetrics
+            title="Ingestion Progress"
+            list={[
+              { label: 'Starting', total: jobStatusCounts.STARTING },
+              { label: 'Running', total: jobStatusCounts.RUNNING },
+              { label: 'Succeeded', total: jobStatusCounts.SUCCEEDED },
+              { label: 'Failed', total: jobStatusCounts.FAILED },
+            ]}
+          />
+        </Grid>
+
+        <Grid xs={12} md={12} lg={12}>
+          <EventLogs title="Event Logs" list={mappedLogs} />
         </Grid>
       </Grid>
     </DashboardContent>
+
   );
 }

--- a/src/sections/dashboard/view/useWebSocket.ts
+++ b/src/sections/dashboard/view/useWebSocket.ts
@@ -1,0 +1,162 @@
+import { useState, useEffect } from 'react';
+
+interface Log {
+  timestamp: number;
+  message: string;
+}
+
+interface JobStatusCounts {
+  SUBMITTED: number;
+  PENDING: number;
+  STARTING: number;
+  RUNNING: number;
+  SUCCEEDED: number;
+  FAILED: number;
+}
+
+interface WebSocketData {
+  logs: Log[];
+  jobStatusCounts: JobStatusCounts;
+  totalVectors: number;
+  totalDocuments: number;
+  vectorsWritten: number;
+  documentsIngested: number;
+  sourceDestinationEmbedding: string;
+}
+
+export const useWebSocket = () => {
+  const [data, setData] = useState<WebSocketData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [socket, setSocket] = useState<WebSocket | null>(null);
+  const [isConnected, setIsConnected] = useState(false);
+
+  useEffect(() => {
+    const websocketUrl = `wss://websocket-url-here/dev`; // Enter websocket url here from CDK deployment
+    const websocket = new WebSocket(websocketUrl);
+
+    websocket.onopen = () => {
+      console.log('WebSocket connection established');
+      setIsConnected(true);
+
+      const initialMessage = {
+        action: 'initialCheck',
+        data: 'Please fetch the current job status and logs.',
+      };
+      websocket.send(JSON.stringify(initialMessage));
+    };
+
+    websocket.onmessage = (event) => {
+      console.log('Received WebSocket message:', event.data);
+      try {
+        const parsedData = JSON.parse(event.data);
+        if (parsedData.type === 'initialCheckResponse') {
+          console.log('Initial connection data received');
+          setData({
+            logs: parsedData.logs || [],
+            jobStatusCounts: parsedData.jobStatusCounts || {
+              SUBMITTED: 0,
+              PENDING: 0,
+              STARTING: 0,
+              RUNNING: 0,
+              SUCCEEDED: 0,
+              FAILED: 0,
+            },
+            totalVectors: parsedData.totalVectors || 0,
+            totalDocuments: parsedData.totalDocuments || 0,
+            vectorsWritten: parsedData.vectorsWritten || 0,
+            documentsIngested: parsedData.documentsIngested || 0,
+            sourceDestinationEmbedding: parsedData.sourceArn || '||',
+          });
+
+          setLoading(false);
+        }
+
+        if (Array.isArray(parsedData.logs)) {
+          setData((prevData) => ({
+            ...prevData!,
+            logs: updateLogs(prevData?.logs || [], parsedData.logs),
+          }));
+        }
+
+        if (parsedData.totalVectors !== undefined) {
+          setData((prevData) => ({
+            ...prevData!,
+            totalVectors: parsedData.totalVectors,
+          }));
+        }
+
+        if (parsedData.totalDocuments !== undefined) {
+          setData((prevData) => ({
+            ...prevData!,
+            totalDocuments: parsedData.totalDocuments,
+          }));
+        }
+
+        if (parsedData.vectorsWritten !== undefined) {
+          setData((prevData) => ({
+            ...prevData!,
+            vectorsWritten: parsedData.vectorsWritten,
+          }));
+        }
+
+        if (parsedData.documentsIngested !== undefined) {
+          setData((prevData) => ({
+            ...prevData!,
+            documentsIngested: parsedData.documentsIngested,
+          }));
+        }
+
+        if (parsedData.jobStatusCounts) {
+          setData((prevData) => ({
+            ...prevData!,
+            jobStatusCounts: parsedData.jobStatusCounts,
+          }));
+        }
+
+        if (parsedData.sourceDestinationEmbedding !== undefined) {
+          setData((prevData) => ({
+            ...prevData!,
+            sourceDestinationEmbedding: parsedData.sourceDestinationEmbedding,
+          }));
+        }
+
+      } catch (error) {
+        console.error('Error parsing WebSocket message:', error);
+      }
+    };
+
+    websocket.onclose = () => {
+      console.log('WebSocket connection closed');
+      setIsConnected(false);
+    };
+
+    websocket.onerror = (error) => {
+      console.error('WebSocket error:', error);
+    };
+
+    setSocket(websocket);
+
+    return () => {
+      if (websocket.readyState === WebSocket.OPEN) {
+        websocket.close();
+      }
+    };
+  }, []);
+
+  const updateLogs = (prevLogs: Log[], newLogs: Log[]): Log[] => {
+    const uniqueLogs = [
+      ...prevLogs.filter(
+        (log) =>
+          !newLogs.some(
+            (newLog) => newLog.timestamp === log.timestamp && newLog.message === log.message
+          )
+      ),
+      ...newLogs,
+    ];
+
+    uniqueLogs.sort((a, b) => b.timestamp - a.timestamp);
+    return uniqueLogs.slice(0, 10);
+  };
+
+  return { data, loading, isConnected };
+};


### PR DESCRIPTION
I added a custom hook to handle the Websockets connection to the Websockets API Gateway created with the CDK deployment. Upon connection or refresh, there is an initial check to populate the front-end with the most recent data. After a new Websocket event, the front-end is populated and re-renders.

Currently, the user will need to enter the Websocket API URL into the front-end code to be able to access that API gateway.